### PR TITLE
Add a generalised Intercom Customer upsert webtask and Mongo Upsert webtask

### DIFF
--- a/intercom/customer-upsert.js
+++ b/intercom/customer-upsert.js
@@ -8,12 +8,11 @@ const URL = 'https://api.intercom.io/users';
  * Insert or update (hence upsert) customer data to Intercom.
  * More info at https://doc.intercom.io/api/#create-or-update-user
  *
- * @param {String} context.data.email - Customer's email, be sure to include this in the update case
- * @param {Object} context.data.attributes - Custom Customer attributes
+ * @param {String} context.data.payload - The payload that you are sending to Intercom
  */
 module.exports = function customerUpsert(context, callback) {
 
-  let { email, attributes, INTERCOM_USER, INTERCOM_PASSWORD } = context.data;
+  let { payload, INTERCOM_USER, INTERCOM_PASSWORD } = context.data;
 
   request.post({
     url: URL,
@@ -21,10 +20,7 @@ module.exports = function customerUpsert(context, callback) {
       user: INTERCOM_USER,
       pass: INTERCOM_PASSWORD
     },
-    json: {
-      "email": email,
-      "custom_attributes": attributes
-    }
+    json: payload
   }, function (err, resp, result) {
     if (err) {
       console.log("Error", err);

--- a/intercom/customer-upsert.js
+++ b/intercom/customer-upsert.js
@@ -1,0 +1,41 @@
+var request = require('request');
+
+const URL = 'https://api.intercom.io/users';
+
+/**
+ * Insert or update (hence upsert) customer data to Intercom.
+ * More info at https://doc.intercom.io/api/#create-or-update-user
+ *
+ * @param {String} context.data.email - Customer's email, be sure to include this in the update case
+ * @param {Object} context.data.attributes - Custom Customer attributes
+ */
+module.exports = function customerUpsert(context, callback) {
+
+  let { email, attributes, INTERCOM_USER, INTERCOM_PASSWORD } = context.data;
+
+  request.post({
+    url: URL,
+    auth: {
+      user: INTERCOM_USER,
+      pass: INTERCOM_PASSWORD
+    },
+    json: {
+      "email": email,
+      "custom_attributes": attributes
+    }
+  }, function (err, resp, result) {
+    if (err) {
+      console.log("Error", err);
+      return callback(err);
+    }
+
+
+    if (resp.statusCode < 200 || resp.statusCode > 299) {
+      console.log("Error", resp.statusCode, result);
+      return callback(new Error(result));
+    }
+
+    console.log("All ok");
+    return callback(null, result);
+  });
+};

--- a/intercom/customer-upsert.js
+++ b/intercom/customer-upsert.js
@@ -1,3 +1,5 @@
+'use latest';
+
 var request = require('request');
 
 const URL = 'https://api.intercom.io/users';

--- a/intercom/customer-upsert.test.js
+++ b/intercom/customer-upsert.test.js
@@ -11,20 +11,22 @@ test('Customer Upsert possitive test', (t) => {
   let resultMock = { text: 'everything is alright' }
   var contextMock = {
     data: {
-      email: 'test@auth0.com',
-      attributes: {
-        custom_attr1: 'hi!'
-      },
       //ATTENTION: this parameters are here only for testing purposes
       //you should always set this parameters as `--secret`
       INTERCOM_USER: 'not a real user',
-      INTERCOM_PASSWORD: 'not a real password'
+      INTERCOM_PASSWORD: 'not a real password',
+      payload: {
+        email: 'test@auth0.com',
+        attributes: {
+          custom_attr1: 'hi!'
+        }
+      }
     }
   };
 
   let api = nock('https://api.intercom.io')
     .post('/users', body => {
-        t.equal(body.email, contextMock.data.email, 'it should send the email as part of the payload');
+        t.equal(body.email, contextMock.data.payload.email, 'it should send the email as part of the payload');
         t.deepEqual(body.custom_attributes, contextMock.data.attributes, 'it should send the attrs as payload');
         return true;
       })

--- a/intercom/customer-upsert.test.js
+++ b/intercom/customer-upsert.test.js
@@ -1,0 +1,63 @@
+import test from 'tape';
+import nock from 'nock';
+import customerUpsert from './customer-upsert.js';
+
+
+// Do not enable any other http call other than the ones mocked
+nock.disableNetConnect();
+
+test('Customer Upsert possitive test', (t) => {
+  t.plan(4);
+  let resultMock = { text: 'everything is alright' }
+  var contextMock = {
+    data: {
+      email: 'test@auth0.com',
+      attributes: {
+        custom_attr1: 'hi!'
+      },
+      //ATTENTION: this parameters are here only for testing purposes
+      //you should always set this parameters as `--secret`
+      INTERCOM_USER: 'not a real user',
+      INTERCOM_PASSWORD: 'not a real password'
+    }
+  };
+
+  let api = nock('https://api.intercom.io')
+    .post('/users', body => {
+        t.equal(body.email, contextMock.data.email, 'it should send the email as part of the payload');
+        t.deepEqual(body.custom_attributes, contextMock.data.attributes, 'it should send the attrs as payload');
+        return true;
+      })
+    .reply(200, resultMock);
+
+
+
+  customerUpsert(contextMock, (err, result) => {
+    t.deepEqual(result, resultMock)
+    t.ok(api.isDone(), 'it should make the POST call')
+  })
+});
+
+
+test('Customer Upsert negative test', (t) => {
+  t.plan(2);
+  let resultMock = { text: 'something bad happened' }
+
+  let api = nock('https://api.intercom.io')
+    .post('/users', body => true)
+    .reply(404);
+
+
+  var context = {
+    data: {
+      email: 'test@auth0.com',
+      INTERCOM_USER: 'not a real user',
+      INTERCOM_PASSWORD: 'not a real password'
+    }
+  };
+
+  customerUpsert(context, (err, result) => {
+    t.ok(err instanceof Error, 'it should return a Javascript Error')
+    t.ok(api.isDone(), 'it should make the POST call')
+  })
+});

--- a/mongo/upsert.js
+++ b/mongo/upsert.js
@@ -8,21 +8,21 @@ let MongoClient = require('mongodb').MongoClient;
  * http://docs.mongodb.org/v2.6/reference/method/db.collection.update/
  *
  * @param {String} context.data.MONGO_URL `--secret` It correspond to the connection url for the db instance.
- * @param {String} context.data.collection `--secret` The name of the db collection where you want to upsert the data
+ * @param {String} context.data.COLLECTION `--secret` The name of the db collection where you want to upsert the data
  * @param {String} context.data.query The query for the object you want to update. If this query throws
  *                    no results, then the dataToUpsert will be inserted into the collection
  * @param {Object} context.data.dataToUpsert Arbirtrary mongodb valid data to upsert in the collection
  */
 module.exports = function mongoUpsert(context, callback) {
 
-  let { MONGO_URL, collection, dataToUpsert, query } = context.data;
+  let { MONGO_URL, COLLECTION, dataToUpsert, query } = context.data;
 
   if (!MONGO_URL) return callback(new Error('MONGO_URL secret is missing'))
 
   MongoClient.connect(MONGO_URL, (err, db) => {
     if(err) return callback(err);
 
-    db.collection(collection)
+    db.collection(COLLECTION)
       .update(query, dataToUpsert, {upsert: true}, (err, result) => {
           if(err) return callback(err);
 

--- a/mongo/upsert.js
+++ b/mongo/upsert.js
@@ -23,7 +23,7 @@ module.exports = function mongoUpsert(context, callback) {
     if(err) return callback(err);
 
     db.collection(COLLECTION)
-      .update(query, dataToUpsert, {upsert: true}, (err, result) => {
+      .update(query, { $set: dataToUpsert }, {upsert: true}, (err, result) => {
           if(err) return callback(err);
 
           db.close();

--- a/mongo/upsert.js
+++ b/mongo/upsert.js
@@ -1,0 +1,33 @@
+"use latest";
+
+let MongoClient = require('mongodb').MongoClient;
+
+
+/**
+ * Webtask wrapper for a MongoDB upsert, for more information checkout their API
+ * http://docs.mongodb.org/v2.6/reference/method/db.collection.update/
+ *
+ * @param {String} context.data.MONGO_URL `--secret` It correspond to the connection url for the db instance.
+ * @param {String} context.data.collection `--secret` The name of the db collection where you want to upsert the data
+ * @param {String} context.data.query The query for the object you want to update. If this query throws
+ *                    no results, then the dataToUpsert will be inserted into the collection
+ * @param {Object} context.data.dataToUpsert Arbirtrary mongodb valid data to upsert in the collection
+ */
+module.exports = function mongoUpsert(context, callback) {
+
+  let { MONGO_URL, collection, dataToUpsert, query } = context.data;
+
+  if (!MONGO_URL) return callback(new Error('MONGO_URL secret is missing'))
+
+  MongoClient.connect(MONGO_URL, (err, db) => {
+    if(err) return callback(err);
+
+    db.collection(collection)
+      .update(query, dataToUpsert, {upsert: true}, (err, result) => {
+          if(err) return callback(err);
+
+          db.close();
+          callback(null, result);
+      });
+  });
+};

--- a/mongo/upsert.test.js
+++ b/mongo/upsert.test.js
@@ -9,7 +9,7 @@ const randomString = () => Math.random().toString(36).substring(7);
 test('Mongo Upsert possitive test', (t) => {
   t.plan(6);
 
-  let collection = 'test';
+  let COLLECTION = 'test';
   let query = { email: `${randomString()}@auth0.com` };
   let dataToUpsert = Object.assign({}, query, { name: 'Jim Morrison' });
 
@@ -18,7 +18,7 @@ test('Mongo Upsert possitive test', (t) => {
       //ATTENTION: this parameter is here only for testing purposes
       //you should always set it as `--secret`
       MONGO_URL,
-      collection,
+      COLLECTION,
       query,
       dataToUpsert
     }

--- a/mongo/upsert.test.js
+++ b/mongo/upsert.test.js
@@ -1,0 +1,53 @@
+import test from 'tape';
+import mongoUpsert from './upsert.js';
+
+
+// This tests required a local mongod instance running in your local
+const MONGO_URL = 'mongodb://127.0.0.1:27017/webtask_test';
+const randomString = () => Math.random().toString(36).substring(7);
+
+test('Mongo Upsert possitive test', (t) => {
+  t.plan(6);
+
+  let collection = 'test';
+  let query = { email: `${randomString()}@auth0.com` };
+  let dataToUpsert = Object.assign({}, query, { name: 'Jim Morrison' });
+
+  let contextMock = {
+    data: {
+      //ATTENTION: this parameter is here only for testing purposes
+      //you should always set it as `--secret`
+      MONGO_URL,
+      collection,
+      query,
+      dataToUpsert
+    }
+  };
+
+  //Insert
+  mongoUpsert(contextMock, (err, { result }) => {
+    t.ok(result.upserted, 'it should insert when the query has no matches');
+    t.equal(result.ok, 1);
+    t.equal(result.nModified, 0);
+
+
+    dataToUpsert.name = 'Kiwi Zulu';
+
+    // Update
+    mongoUpsert(contextMock, (err, { result }) => {
+      t.ok(!result.upserted);
+      t.equal(result.ok, 1);
+      t.equal(result.nModified, 1, 'it should update the existing document');
+    })
+  })
+});
+
+test('Mongo Upsert negative test: no mongo URL', (t) => {
+  t.plan(1);
+
+  let contextMock = { data: {} };
+
+  mongoUpsert(contextMock, (err, result) => {
+    t.ok(err instanceof Error, 'it should return a javascript error');
+  })
+});

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
   "homepage": "https://github.com/auth0/webtask-scripts",
   "devDependencies": {
     "babel": "^5.8.20",
+    "mongodb": "^2.0.39",
     "nock": "^2.9.1",
     "request": "^2.60.0",
     "tape": "^4.0.1"

--- a/package.json
+++ b/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "webtask-scripts",
+  "version": "1.0.0",
+  "description": "",
+  "main": "webtask.js",
+  "scripts": {
+    "test": "babel-node **/*.test.js"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/auth0/webtask-scripts"
+  },
+  "author": "",
+  "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/auth0/webtask-scripts/issues"
+  },
+  "homepage": "https://github.com/auth0/webtask-scripts",
+  "devDependencies": {
+    "babel": "^5.8.20",
+    "nock": "^2.9.1",
+    "request": "^2.60.0",
+    "tape": "^4.0.1"
+  }
+}


### PR DESCRIPTION
- Created `customer-upsert.js` and tested it.
- Created mongo `upsert.js` and tested it.
- You can run `npm test` as a sort of test harness (you need mongo installed in your local with the default configs to run the mongo upsert test)