### PR TITLE
Add jenkins remote api webtask

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,6 @@ node_modules
 
 # Users Environment Variables
 .lock-wscript
+
+# Exclude build dirs
+dist

--- a/jenkins-remote-api/.babelrc
+++ b/jenkins-remote-api/.babelrc
@@ -1,0 +1,4 @@
+{
+  "presets": ["es2015-node4", "stage-0"],
+  "plugins": ["add-module-exports"]
+}

--- a/jenkins-remote-api/.editorconfig
+++ b/jenkins-remote-api/.editorconfig
@@ -1,0 +1,10 @@
+[*]
+indent_style = space
+end_of_line = lf
+indent_size = 2
+charset = utf-8
+trim_trailing_whitespace = true
+
+[*.md]
+max_line_length = 0
+trim_trailing_whitespace = false

--- a/jenkins-remote-api/.eslintignore
+++ b/jenkins-remote-api/.eslintignore
@@ -1,0 +1,2 @@
+node_modules/*
+dist/*

--- a/jenkins-remote-api/.eslintrc
+++ b/jenkins-remote-api/.eslintrc
@@ -1,0 +1,3 @@
+{
+  "extends": "auth0/base"
+}

--- a/jenkins-remote-api/LICENSE.md
+++ b/jenkins-remote-api/LICENSE.md
@@ -1,0 +1,21 @@
+The MIT License (MIT)
+
+Copyright (c) 2016 Auth0, Inc. <support@auth0.com> (https://auth0.com)
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/jenkins-remote-api/README.md
+++ b/jenkins-remote-api/README.md
@@ -1,0 +1,53 @@
+# Webtask Jenkins Remote API
+
+Webtask to use Jenkins Remote API with CSRF Protection and keep safe your Jenkins token.
+
+## Run locally
+
+For testing purposes
+
+`npm start`
+
+## Deploy to webtask
+
+`npm run deploy`
+
+## Example
+
+Fill config files:
+
+`config/default.config.json`:
+```json
+{
+  "params": {},
+  "secret": {
+    "JENKINS_USER": "user@company.com",
+    "JENKINS_TOKEN": "<jenkins token>",
+    "JENKINS_URL": "https://jenkins.company.com",
+    "JENKINS_PATH": "/job/website/build"
+  }
+}
+
+```
+`config/webtask.config.json`:
+```json
+{
+  "WEBTASK_NAME": "build-company-website",
+  "WEBTASK_TOKEN": "<webtask token>"
+}
+
+```
+Deploy to webtask: `npm run deploy`
+
+and finally just:
+```sh
+curl -i -H "Accept: application/json" -H "Content-Type: application/json" -X GET https://webtask.it.auth0.com/api/run/wt-user/build-company-website
+```
+
+## Issue Reporting
+
+If you have found a bug or if you have a feature request, please report them at this repository issues section. Please do not report security vulnerabilities on the public GitHub issue tracker. The [Responsible Disclosure Program](https://auth0.com/whitehat) details the procedure for disclosing security issues.
+
+## License
+
+Webtask Jenkins Remote API is [MIT licensed](./LICENSE.md).

--- a/jenkins-remote-api/config/default.config.json
+++ b/jenkins-remote-api/config/default.config.json
@@ -1,0 +1,9 @@
+{
+  "params": {},
+  "secret": {
+    "JENKINS_USER": "",
+    "JENKINS_TOKEN": "",
+    "JENKINS_URL": "",
+    "JENKINS_PATH": ""
+  }
+}

--- a/jenkins-remote-api/config/webtask.config.json
+++ b/jenkins-remote-api/config/webtask.config.json
@@ -1,0 +1,4 @@
+{
+  "WEBTASK_NAME": "jenkins-remote-api",
+  "WEBTASK_TOKEN": ""
+}

--- a/jenkins-remote-api/package.json
+++ b/jenkins-remote-api/package.json
@@ -1,0 +1,43 @@
+{
+  "name": "jenkins-remote-api",
+  "version": "1.0.0",
+  "description": "Webtask to use Jenkins Remote API with CSRF Protection and keep safe your Jenkins token",
+  "main": "dist/node.js",
+  "scripts": {
+    "start": "node tools/development",
+    "build": "webpack --config tools/webpack.config.js",
+    "build:production": "NODE_ENV=production npm run build",
+    "predeploy": "npm run build:production",
+    "deploy": "node tools/deploy",
+    "test": "npm run lint",
+    "lint": "eslint ."
+  },
+  "author": "Auth0 Inc. <support@auth0.com> (https://auth0.com)",
+  "license": "MIT",
+  "repository": "https://github.com/auth0/webtask-scripts/tree/master/jenkins-remote-api",
+  "engines": {
+    "node": ">=4.0.0 <5.0.0",
+    "npm": ">=2.0.0 <3.0.0"
+  },
+  "dependencies": {
+    "axios": "^0.13.1",
+    "source-map-support": "^0.4.2"
+  },
+  "devDependencies": {
+    "babel-core": "^6.11.4",
+    "babel-loader": "^6.2.4",
+    "babel-plugin-add-module-exports": "^0.2.1",
+    "babel-preset-es2015-node4": "^2.1.0",
+    "babel-preset-stage-0": "^6.5.0",
+    "eslint": "^2.13.1",
+    "eslint-config-auth0": "^2.0.0",
+    "eslint-plugin-jsx-a11y": "^0.6.2",
+    "eslint-plugin-react": "^4.3.0",
+    "json-loader": "^0.5.4",
+    "lodash": "^4.14.1",
+    "nodemon": "^1.10.0",
+    "sandboxjs": "^3.0.0",
+    "webpack": "^1.13.1",
+    "webpack-node-externals": "^1.3.3"
+  }
+}

--- a/jenkins-remote-api/src/node.js
+++ b/jenkins-remote-api/src/node.js
@@ -1,0 +1,12 @@
+import _ from 'lodash';
+import jenkinsRemoteApi from './webtask';
+import defaultConfig from '../config/default.config.json';
+
+const data = { data: _.assign({}, defaultConfig.secret, defaultConfig.param) };
+
+jenkinsRemoteApi(data, (err, message) => {
+  if (err) throw err;
+
+  // eslint-disable-next-line no-console
+  console.log(message);
+});

--- a/jenkins-remote-api/src/webtask.js
+++ b/jenkins-remote-api/src/webtask.js
@@ -1,0 +1,34 @@
+import axios from 'axios';
+
+function jenkinsRemoteApi({ data }, callback) {
+  const JENKINS_URL = data.JENKINS_URL;
+  const JENKINS_USER = data.JENKINS_USER;
+  const JENKINS_TOKEN = data.JENKINS_TOKEN;
+  const JENKINS_PATH = data.JENKINS_PATH;
+
+  const httpClient = axios.create({
+    baseURL: JENKINS_URL,
+    auth: {
+      username: JENKINS_USER,
+      password: JENKINS_TOKEN
+    }
+  });
+
+  httpClient('/crumbIssuer/api/json')
+    .then(response => {
+      const crumbIssuer = response.data;
+
+      return httpClient({
+        method: 'post',
+        url: JENKINS_PATH,
+        headers: {
+          [crumbIssuer.crumbRequestField]: crumbIssuer.crumb
+        }
+      });
+    })
+    .then(response => callback(null, response.data))
+    .catch(error => callback(error.response.data));
+}
+
+
+export default jenkinsRemoteApi;

--- a/jenkins-remote-api/tools/deploy.js
+++ b/jenkins-remote-api/tools/deploy.js
@@ -1,0 +1,32 @@
+const fs = require('fs');
+const _ = require('lodash');
+const sandbox = require('sandboxjs');
+const webtaskConfig = require('../config/webtask.config');
+const defaultConfig = require('../config/default.config');
+
+const config = _.assign({}, defaultConfig, webtaskConfig);
+
+if (!config.WEBTASK_NAME) {
+  throw new Error('error deploying webtask: Missing webtask name, please define the webtaskName');
+}
+
+if (!config.WEBTASK_TOKEN) {
+  throw new Error('error deploying webtask: Missing webtask token, please define the webtaskToken');
+}
+
+const profile = sandbox.fromToken(config.WEBTASK_TOKEN);
+
+fs.readFile('dist/webtask.js', (fsErr, code) => {
+  if (fsErr) throw fsErr;
+
+  profile.create(code.toString(), {
+    name: config.WEBTASK_NAME,
+    secrets: config.secret,
+    params: config.param
+  }, (sbErr, webtask) => {
+    if (sbErr) throw sbErr;
+
+    // eslint-disable-next-line no-console
+    console.log(webtask.url);
+  });
+});

--- a/jenkins-remote-api/tools/development.js
+++ b/jenkins-remote-api/tools/development.js
@@ -1,0 +1,16 @@
+const nodemon = require('nodemon');
+const _ = require('lodash');
+const webpack = require('webpack');
+const webpackConfig = require('./webpack.config');
+
+const bundler = webpack(webpackConfig);
+const runNodemon = _.once(() => nodemon('dist/node.js'));
+
+bundler.watch({}, (err, stats) => {
+  if (err) throw err;
+
+  runNodemon();
+
+  // eslint-disable-next-line no-console
+  console.log(stats.toString());
+});

--- a/jenkins-remote-api/tools/webpack.config.js
+++ b/jenkins-remote-api/tools/webpack.config.js
@@ -1,0 +1,66 @@
+const path = require('path');
+const _ = require('lodash');
+const webpack = require('webpack');
+const nodeExternals = require('webpack-node-externals');
+
+const DEBUG = process.env.NODE_ENV !== 'production';
+
+// Common configuration chunk to be used on all bundles
+// webtask (webtask.js), and normal (node.js) bundles
+const defaultConfig = {
+  context: path.resolve(__dirname, '../src'),
+
+  output: {
+    path: path.join(__dirname, '../dist'),
+    libraryTarget: 'commonjs2'
+  },
+
+  module: {
+    loaders: [{
+      test: /\.js$/,
+      loader: 'babel',
+      include: path.join(__dirname, '../src')
+    }, {
+      test: /\.json$/,
+      loader: 'json'
+    }]
+  },
+
+  externals: [nodeExternals({
+    whitelist: ['axios']
+  })],
+
+  target: 'node',
+
+  debug: true,
+
+  devtool: DEBUG ? 'source-map' : false,
+
+  plugins: [
+    new webpack.optimize.OccurenceOrderPlugin(),
+    new webpack.BannerPlugin('require("source-map-support").install();', {
+      raw: true,
+      entryOnly: false
+    })
+  ]
+};
+
+// Configuration for the webtask bundle (webtask.js)
+const indexConfig = _.merge({}, defaultConfig, {
+  entry: ['./webtask'],
+
+  output: {
+    filename: 'webtask.js'
+  }
+});
+
+// Configuration for the normal bundle (node.js)
+const runConfig = _.merge({}, defaultConfig, {
+  entry: ['./node'],
+
+  output: {
+    filename: 'node.js'
+  }
+});
+
+module.exports = [indexConfig, runConfig];


### PR DESCRIPTION
# Webtask Jenkins Remote API

Webtask to use Jenkins Remote API with CSRF Protection and keep safe your Jenkins token.

## Run locally

For testing purposes

`npm start`

## Deploy to webtask

`npm run deploy`

## Example

Fill config files:

`config/default.config.json`:
```json
{
  "params": {},
  "secret": {
    "JENKINS_USER": "user@company.com",
    "JENKINS_TOKEN": "<jenkins token>",
    "JENKINS_URL": "https://jenkins.company.com",
    "JENKINS_PATH": "/job/website/build"
  }
}

```
`config/webtask.config.json`:
```json
{
  "WEBTASK_NAME": "build-company-website",
  "WEBTASK_TOKEN": "<webtask token>"
}

```
Deploy to webtask: `npm run deploy`

and finally just:
```sh
curl -i -H "Accept: application/json" -H "Content-Type: application/json" -X GET https://webtask.it.auth0.com/api/run/wt-user/build-company-website
```
