### PR TITLE
Add sftp to s3 from list webtask

### DIFF
--- a/sftp-to-s3-from-list/.babelrc
+++ b/sftp-to-s3-from-list/.babelrc
@@ -1,0 +1,4 @@
+{
+  "presets": ["es2015", "stage-0"],
+  "plugins": ["add-module-exports", "transform-runtime"]
+}

--- a/sftp-to-s3-from-list/.editorconfig
+++ b/sftp-to-s3-from-list/.editorconfig
@@ -1,0 +1,10 @@
+[*]
+indent_style = space
+end_of_line = lf
+indent_size = 2
+charset = utf-8
+trim_trailing_whitespace = true
+
+[*.md]
+max_line_length = 0
+trim_trailing_whitespace = false

--- a/sftp-to-s3-from-list/.eslintignore
+++ b/sftp-to-s3-from-list/.eslintignore
@@ -1,0 +1,2 @@
+node_modules/*
+dist/*

--- a/sftp-to-s3-from-list/.eslintrc
+++ b/sftp-to-s3-from-list/.eslintrc
@@ -1,0 +1,4 @@
+{
+  "extends": "auth0/base",
+  "parser": "babel-eslint"
+}

--- a/sftp-to-s3-from-list/LICENSE.md
+++ b/sftp-to-s3-from-list/LICENSE.md
@@ -1,0 +1,21 @@
+The MIT License (MIT)
+
+Copyright (c) 2016 Auth0, Inc. <support@auth0.com> (https://auth0.com)
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/sftp-to-s3-from-list/README.md
+++ b/sftp-to-s3-from-list/README.md
@@ -1,0 +1,53 @@
+# Webtask SFTP to AWS S3 from list of files
+
+Copy all files from a SFTP (via a list of files) to AWS S3. Especially to use with [Webtask SFTP List](https://github.com/auth0/webtask-scripts/tree/master/sftp-list).
+
+## Run locally
+
+For testing purposes
+
+`npm start`
+
+## Deploy to webtask
+
+`npm run deploy`
+
+## Example
+
+Fill config files:
+
+`config/default.config.json`:
+```json
+{
+  "secret": {
+    "host": "<ssh2 host url>",
+    "port": "<ssh2 port>",
+    "username": "<SSH2 USER>",
+    "password": "<SSH2 user password>",
+    "path": "<Path to replace with '' while uploading to S3>",
+    "accessKeyId": "<AWS Access Key ID>",
+    "secretAccessKey": "<AWS Secret Access Key>",
+    "bucket": "<AWS S3 Bucket>"
+  },
+  "param": {
+    "path": "<path to replace when uploading to S3>"
+  }
+}
+```
+`config/webtask.config.json`:
+```json
+{
+  "WEBTASK_NAME": "sftp-to-s3-from-list",
+  "WEBTASK_TOKEN": "<Webtask token>"
+}
+
+```
+Deploy to webtask: `npm run deploy`
+
+## Issue Reporting
+
+If you have found a bug or if you have a feature request, please report them at this repository issues section. Please do not report security vulnerabilities on the public GitHub issue tracker. The [Responsible Disclosure Program](https://auth0.com/whitehat) details the procedure for disclosing security issues.
+
+## License
+
+Webtask SFTP List is [MIT licensed](./LICENSE.md).

--- a/sftp-to-s3-from-list/config/default.config.json
+++ b/sftp-to-s3-from-list/config/default.config.json
@@ -1,0 +1,14 @@
+{
+  "secret": {
+    "host": "",
+    "port": "",
+    "username": "",
+    "password": "",
+    "accessKeyId": "",
+    "secretAccessKey": "",
+    "bucket": ""
+  },
+  "param": {
+    "path": ""
+  }
+}

--- a/sftp-to-s3-from-list/config/webtask.config.json
+++ b/sftp-to-s3-from-list/config/webtask.config.json
@@ -1,0 +1,4 @@
+{
+  "WEBTASK_NAME": "sftp-to-s3-from-list",
+  "WEBTASK_TOKEN": ""
+}

--- a/sftp-to-s3-from-list/package.json
+++ b/sftp-to-s3-from-list/package.json
@@ -1,0 +1,49 @@
+{
+  "name": "sftp-to-s3-from-list",
+  "version": "1.0.0",
+  "description": "Copy all files from a SFTP (via a list of files) to AWS S3",
+  "main": "dist/node.js",
+  "scripts": {
+    "start": "node tools/development",
+    "build": "webpack --config tools/webpack.config.js",
+    "build:production": "NODE_ENV=production npm run build",
+    "predeploy": "npm run build:production",
+    "deploy": "node tools/deploy",
+    "test": "npm run lint",
+    "lint": "eslint ."
+  },
+  "author": "Auth0 Inc. <support@auth0.com> (https://auth0.com)",
+  "license": "MIT",
+  "repository": "https://github.com/auth0/webtask-scripts/tree/master/sftp-to-s3-from-list",
+  "engines": {
+    "node": ">=4.0.0 <5.0.0",
+    "npm": ">=2.0.0 <3.0.0"
+  },
+  "dependencies": {
+    "aws-sdk": "^2.4.13",
+    "babel-runtime": "^6.11.6",
+    "body-parser": "^1.15.2",
+    "express": "^4.14.0",
+    "mime": "^1.3.4",
+    "replacestream": "^4.0.0",
+    "source-map-support": "^0.4.2",
+    "ssh2": "^0.5.0"
+  },
+  "devDependencies": {
+    "babel-core": "^6.11.4",
+    "babel-eslint": "^6.1.2",
+    "babel-loader": "^6.2.4",
+    "babel-plugin-add-module-exports": "^0.2.1",
+    "babel-plugin-transform-runtime": "^6.12.0",
+    "babel-preset-es2015": "^6.9.0",
+    "babel-preset-stage-0": "^6.5.0",
+    "eslint": "^2.13.1",
+    "eslint-config-auth0": "^2.0.0",
+    "json-loader": "^0.5.4",
+    "lodash": "^4.14.1",
+    "nodemon": "^1.10.0",
+    "sandboxjs": "^3.0.0",
+    "webpack": "^1.13.1",
+    "webpack-node-externals": "^1.3.3"
+  }
+}

--- a/sftp-to-s3-from-list/src/node.js
+++ b/sftp-to-s3-from-list/src/node.js
@@ -1,0 +1,40 @@
+import { assign, isFunction } from 'lodash';
+import express from 'express';
+import sftpToS3FromList from './webtask';
+import defaultConfig from '../config/default.config.json';
+
+const app = express();
+
+app.use((req, res, next) => {
+  // eslint-disable-next-line no-param-reassign
+  req.webtaskContext = generateWebtaskContext(defaultConfig.secret, defaultConfig.param);
+
+  return next();
+});
+
+app.use('/', sftpToS3FromList);
+
+app.listen(3000, () => {
+  console.log('Listen on port 3000');
+});
+
+function generateWebtaskContext(secrets, params) {
+  const context = {
+    data: assign({}, secrets, params),
+    body: secrets,
+    storage: {
+      memory: null,
+      set(data, options, cb) {
+        // eslint-disable-next-line no-param-reassign
+        if (isFunction(options)) cb = options;
+        this.memory = data;
+        cb(null);
+      },
+      get(cb) {
+        cb(null, this.memory);
+      }
+    }
+  };
+
+  return context;
+}

--- a/sftp-to-s3-from-list/src/webtask.js
+++ b/sftp-to-s3-from-list/src/webtask.js
@@ -1,0 +1,284 @@
+import AWS from 'aws-sdk';
+import ssh2 from 'ssh2';
+import mime from 'mime';
+import assert from 'assert';
+import express from 'express';
+import bodyParser from 'body-parser';
+import { isObject, isArray, isString } from 'lodash';
+import stream from 'stream';
+// import replacestream from 'replacestream';
+
+const app = express();
+
+export default app;
+
+// Parse application/x-www-form-urlencoded and application/json
+app.use(bodyParser.json({ limit: '1mb' }));
+app.use(bodyParser.urlencoded({ limit: '1mb', extended: false }));
+
+app.post('/', sftpToS3FromList);
+
+async function sftpToS3FromList(req, res) {
+  const { webtaskContext, body } = req;
+  const { data, storage } = webtaskContext;
+  const { host, port, username, password, path, accessKeyId, secretAccessKey, bucket } = data;
+  const listFiles = validateListFiles(body['listFiles[]'])
+    ? JSON.parse(body['listFiles[]'])
+    : null;
+
+  // Check required secrets and params
+  try {
+    assert(host, 'host secret required');
+    assert(port, 'port secret required');
+    assert(username, 'username secret required');
+    assert(password, 'password secret required');
+    assert(path, 'path param required');
+    assert(accessKeyId, 'accessKeyId secret required');
+    assert(secretAccessKey, 'secretAccessKey secret required');
+    assert(bucket, 'bucket secret required');
+  } catch (e) {
+    return res.status(500).json(e);
+  }
+
+  // SSH2, AWS S3 and S3 Upload Stream clients
+  const SSH2Client = ssh2.Client;
+  const connection = new SSH2Client();
+  const s3Client = new AWS.S3({
+    accessKeyId,
+    secretAccessKey,
+    sslEnabled: true,
+    params: {
+      Bucket: bucket
+    }
+  });
+  let files;
+
+  try {
+    // Write in storage files list to upload or get remaining files from storage
+    if (listFiles) {
+      files = { total: listFiles.files, remaining: listFiles.files };
+      await storageSet(storage, files, { force: 1 });
+    } else {
+      files = await storageGet(storage);
+    }
+
+    if (!files) {
+      throw new Error('There isn\'t a file list to upload, please send via POST form-data key ' +
+        '`fileList[]`');
+    }
+
+    // eslint-disable-next-line no-console
+    console.log(filesCount(files));
+
+    // Start SSH2 connection and then SFTP connection
+    await connectSSH2({ connection, host, port, username, password });
+    const sftpConnection = await connectSFTP(connection);
+
+    // Main: SFTP to S3 from list
+    for (const filePath of files.remaining) {
+      /* eslint-disable no-console */
+      // Download file
+      const readStream = await downloadFile(sftpConnection, filePath);
+      console.log(`Successfully downloaded ${filePath} from SFTP`);
+      // Upload file
+      await uploadFile({ s3Client, path, filePath, readStream });
+      console.log(`Successfully uploaded ${filePath} to S3`);
+      // Remove file from storage.remaining
+      const filesUpdated = Object.assign({}, files, {
+        remaining: files.remaining.filter(item => item !== filePath)
+      });
+      files = filesUpdated;
+      await storageSet(storage, filesUpdated, { force: 1 });
+      // eslint-disable-line no-console
+      console.log(`Successfully removed ${filePath} from storage`);
+    }
+
+    // End SSH2 and SFTP connections
+    sftpConnection.end();
+    connection.end();
+
+    return res.status(200).json({ files: filesCount(files) });
+  } catch (e) {
+    connection.end();
+
+    return res.status(500).json({ message: e.message, files: filesCount(files) });
+  }
+}
+
+/**
+ * Validate list of files received via POST x-www-form-urlencoded
+ * e.g.: { files: ['/file.js', '/path/file.js'] }
+ *
+ * @param {string} listFiles - Data received via POST x-www-form-urlencoded
+ */
+function validateListFiles(listFiles) {
+  let parsedListFiles = null;
+
+  if (!listFiles) return false;
+  try {
+    parsedListFiles = JSON.parse(listFiles);
+  } catch (e) {
+    return false;
+  }
+
+  if (!isObject(parsedListFiles)) return false;
+  if (!parsedListFiles.files) return false;
+  if (!isArray(parsedListFiles.files)) return false;
+  if (!parsedListFiles.files.every(filePath => isString(filePath))) return false;
+
+  return true;
+}
+
+/**
+ * Get files count of { total: [...], remaining: [...] }
+ *
+ * @param {object} files - { total: [...], remaining: [...] }
+ */
+function filesCount(files) {
+  const total = files && files.total ? files.total.length : 0;
+  const remaining = files && files.remaining ? files.remaining.length : 0;
+
+  return { total, remaining };
+}
+
+/**
+ * Start SSH2 connection
+ *
+ * @param {object} options
+ * @param {object} options.connection - npm:ssh2 client connection
+ * @param {string} options.host - SSH2 host url
+ * @param {number} options.port - SSH2 port number
+ * @param {string} options.username - SSH2 username
+ * @param {string} options.password - SSH2 password
+ */
+function connectSSH2({ connection, host, port, username, password }) {
+  return new Promise((resolve, reject) => {
+    connection
+      // Authentication was successful
+      .on('ready', resolve)
+      // An error occurred
+      .on('error', reject)
+      // Start connection
+      .connect({ host, port, username, password });
+  });
+}
+
+/**
+ * Start SFTP connection
+ *
+ * @param {object} connection - npm:ssh2 client connection
+ * @returns {object} npm:ssh2 SFTP connection
+ */
+function connectSFTP(connection) {
+  return new Promise((resolve, reject) => {
+    connection.sftp((errSftp, sftp) => {
+      if (errSftp) {
+        sftp.end();
+        return reject(errSftp);
+      }
+
+      return resolve(sftp);
+    });
+  });
+}
+
+/**
+ * Download file from SFTP
+ *
+ * @param {object} sftp - npm:ssh2 sftp connection
+ * @param {string} filePath - File path. E.g. '/folder/file.js'
+ * @returns {object} Read stream of the downloaded file
+ */
+function downloadFile(sftp, filePath) {
+  return new Promise(resolve => {
+    const readStream = sftp.createReadStream(filePath);
+    return resolve(readStream);
+  });
+}
+
+/**
+ * Upload a file to AWS S3
+ *
+ * @param {object} options
+ * @param {object} options.s3Client - AWS S3 client instance
+ * @param {string} options.filePath - File path. E.g. '/folder/file.js'
+ * @param {object} options.readStream - file read stream
+ */
+function uploadFile({ s3Client, path, filePath, readStream }) {
+  return new Promise((resolve, reject) => {
+    if (/\.(js|css|xml|htm|html)$/.test(filePath)) {
+      // TODO: Find a way to make dynamically replacements with pipes and move to webtask params
+      //
+      // const replaces = [{
+      //   search: 'a',
+      //   replacement: 'b'
+      // }, {
+      //   search: 'c',
+      //   replacement: 'a'
+      // }, {
+      //   search: 'foo',
+      //   replacement: 'bar'
+      // }];
+      //
+      // replaces.forEach(({ search, replacement }) => {
+      //   readStream.pipe(replacestream(search, replacement));
+      // });
+      // readStream
+      //   .pipe(uploadFromStream(s3Client, mime.lookup(filePath), filePath.replace(path, '')));
+
+      readStream
+        // Hacky workaround
+        //
+        // .pipe(replacestream('a', 'b'))
+        // .pipe(replacestream('c', 'a'))
+        // .pipe(replacestream('foo', 'bar'))
+        .pipe(uploadFromStream(s3Client, mime.lookup(filePath), filePath.replace(path, '')));
+    } else {
+      readStream
+        .pipe(uploadFromStream(s3Client, mime.lookup(filePath), filePath.replace(path, '')));
+    }
+
+    function uploadFromStream(s3, ContentType, Key) {
+      const Body = new stream.PassThrough();
+      const params = { ContentType, Key, Body };
+
+      s3.upload(params, (err, data) => {
+        if (err) reject(err);
+        resolve(data);
+      });
+
+      return Body;
+    }
+  });
+}
+
+/**
+ * Webtask Storage API write data promisified
+ *
+ * @param {object} storage - Webtask Storage API
+ * @param {object} data - Data to save on Webtask Storage
+ * @param {object} data - Options for write on Webtask Storage
+ */
+function storageSet(storage, data, options) {
+  return new Promise((resolve, reject) => {
+    storage.set(data, options, (error) => {
+      if (error) return reject(error);
+      return resolve();
+    });
+  });
+}
+
+/**
+ * Webtask Storage API read data promisified
+ *
+ * @param {object} storage - Webtask Storage API
+ * @returns {object} Data from Webtask Storage
+ */
+function storageGet(storage) {
+  return new Promise((resolve, reject) => {
+    storage.get((error, data) => {
+      if (error) return reject(error);
+      return resolve(data);
+    });
+  });
+}

--- a/sftp-to-s3-from-list/tools/deploy.js
+++ b/sftp-to-s3-from-list/tools/deploy.js
@@ -1,0 +1,36 @@
+const fs = require('fs');
+const _ = require('lodash');
+const sandbox = require('sandboxjs');
+const webtaskConfig = require('../config/webtask.config');
+const defaultConfig = require('../config/default.config');
+
+const config = _.assign({}, defaultConfig, webtaskConfig);
+
+if (!config.WEBTASK_NAME) {
+  throw new Error('error deploying webtask: Missing webtask name, please define the WEBTASK_NAME');
+}
+
+if (!config.WEBTASK_TOKEN) {
+  throw new Error('error deploying webtask: Missing webtask token, please define the' +
+    ' WEBTASK_TOKEN');
+}
+
+const profile = sandbox.fromToken(config.WEBTASK_TOKEN);
+
+fs.readFile('dist/webtask.js', (fsErr, code) => {
+  if (fsErr) throw fsErr;
+
+  profile.create(code.toString(), {
+    name: config.WEBTASK_NAME,
+    secrets: config.secret,
+    params: config.param,
+    meta: {
+      'wt-compiler': 'webtask-tools/express'
+    }
+  }, (sbErr, webtask) => {
+    if (sbErr) throw sbErr;
+
+    // eslint-disable-next-line no-console
+    console.log(webtask.url);
+  });
+});

--- a/sftp-to-s3-from-list/tools/development.js
+++ b/sftp-to-s3-from-list/tools/development.js
@@ -1,0 +1,16 @@
+const nodemon = require('nodemon');
+const _ = require('lodash');
+const webpack = require('webpack');
+const webpackConfig = require('./webpack.config');
+
+const bundler = webpack(webpackConfig);
+const runNodemon = _.once(() => nodemon('dist/node.js'));
+
+bundler.watch({}, (err, stats) => {
+  if (err) throw err;
+
+  runNodemon();
+
+  // eslint-disable-next-line no-console
+  console.log(stats.toString(webpackConfig[0].stats));
+});

--- a/sftp-to-s3-from-list/tools/webpack.config.js
+++ b/sftp-to-s3-from-list/tools/webpack.config.js
@@ -1,0 +1,67 @@
+const path = require('path');
+const _ = require('lodash');
+const webpack = require('webpack');
+const nodeExternals = require('webpack-node-externals');
+
+// Common configuration chunk to be used on all bundles
+// webtask (webtask.js), and normal (node.js) bundles
+const defaultConfig = {
+  context: path.resolve(__dirname, '../src'),
+
+  output: {
+    path: path.join(__dirname, '../dist'),
+    libraryTarget: 'commonjs2'
+  },
+
+  module: {
+    loaders: [{
+      test: /\.js$/,
+      loader: 'babel',
+      include: path.join(__dirname, '../src')
+    }, {
+      test: /\.json$/,
+      loader: 'json'
+    }]
+  },
+
+  externals: [nodeExternals({
+    whitelist: ['s3-upload-stream', 'replacestream']
+  })],
+
+  target: 'node',
+
+  debug: true,
+
+  devtool: 'source-map',
+
+  plugins: [
+    new webpack.BannerPlugin('require("source-map-support").install();', {
+      raw: true,
+      entryOnly: false
+    })
+  ],
+
+  stats: {
+    colors: true
+  }
+};
+
+// Configuration for the webtask bundle (webtask.js)
+const indexConfig = _.merge({}, defaultConfig, {
+  entry: ['./webtask'],
+
+  output: {
+    filename: 'webtask.js'
+  }
+});
+
+// Configuration for the normal bundle (node.js)
+const runConfig = _.merge({}, defaultConfig, {
+  entry: ['./node'],
+
+  output: {
+    filename: 'node.js'
+  }
+});
+
+module.exports = [indexConfig, runConfig];


### PR DESCRIPTION
# Webtask SFTP to AWS S3 from list of files

Copy all files from a SFTP (via a list of files) to AWS S3

## Run locally

For testing purposes

`npm start`

## Deploy to webtask

`npm run deploy`

## Example

Fill config files:

`config/default.config.json`:
```json
{
  "secret": {
    "host": "<ssh2 host url>",
    "port": "<ssh2 port>",
    "username": "<SSH2 USER>",
    "password": "<SSH2 user password>",
    "path": "<Path to replace with '' while uploading to S3>",
    "accessKeyId": "<AWS Access Key ID>",
    "secretAccessKey": "<AWS Secret Access Key>",
    "bucket": "<AWS S3 Bucket>"
  },
  "param": {
    "path": "<path to replace when uploading to S3>"
  }
}
```
`config/webtask.config.json`:
```json
{
  "WEBTASK_NAME": "sftp-to-s3-from-list",
  "WEBTASK_TOKEN": "<Webtask token>"
}

```
Deploy to webtask: `npm run deploy`